### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,23 @@ In this workspace you will find 4 Github branches:
 ### int/testapp
 You pick this branch if are an integrator and all you need is to quickly get started with the R2 Testapp. 
 
-1. git clone --recurse-submodules -b int/testapp https://github.com/readium/r2-workspace-kotlin.git r2-workspace-kotlin
-2. in Android Studio **Open an existing Android Studio project** and select the **r2-workspace-kotlin** directory
-3. run configuration **r2-testapp** 
+[https://github.com/readium/r2-workspace-kotlin/tree/int/testapp](https://github.com/readium/r2-workspace-kotlin/tree/int/testapp)
 
 ### dev/testapp
 You pick this branch if are an developer and a R2 contributor. You can get started quickly on the R2 Testapp and it's modules with this branch. We do appreciate any contribution, no matter how small it is, it makes a difference :) 
 
-1. git clone --recurse-submodules -b dev/testapp https://github.com/readium/r2-workspace-kotlin.git r2-workspace-kotlin
-2. in Android Studio **Open an existing Android Studio project** and select the **r2-workspace-kotlin** directory
-3. run configuration **r2-testapp** 
-
+[https://github.com/readium/r2-workspace-kotlin/tree/dev/testapp](https://github.com/readium/r2-workspace-kotlin/tree/dev/testapp)
 
 
 ### int/testapp-with-lcp
 You pick this branch if are an integrator and you would like to get started with the R2 Testapp supporting LCP. 
 
-1. git clone --recurse-submodules -b int/testapp-with-lcp https://github.com/readium/r2-workspace-kotlin.git r2-workspace-kotlin
-2. copy **liblcp.aar** into the **liblcp** directory
-3. in Android Studio **Open an existing Android Studio project** and select the **r2-workspace-kotlin** directory
-4. run configuration **r2-testapp** 
-
+[https://github.com/readium/r2-workspace-kotlin/tree/int/testapp-with-lcp](https://github.com/readium/r2-workspace-kotlin/tree/int/testapp-with-lcp)
 
 ### dev/testapp-with-lcp
 You pick this branch if are an developer and a R2 contributor. You can get started quickly on the R2 Testapp and it's modules including LCP with this branch. We do appreciate any contribution, no matter how small it is, it makes a difference :) 
 
-1. git clone --recurse-submodules -b dev/testapp-with-lcp https://github.com/readium/r2-workspace-kotlin.git r2-workspace-kotlin
-2. copy **liblcp.aar** into the **liblcp** directory
-3. in Android Studio **Open an existing Android Studio project** and select the **r2-workspace-kotlin** directory
-4. run configuration **r2-testapp** 
-
+[https://github.com/readium/r2-workspace-kotlin/tree/dev/testapp-with-lcp](https://github.com/readium/r2-workspace-kotlin/tree/dev/testapp-with-lcp)
 
 
 ## Getting the pre-compiled Readium LCP module.


### PR DESCRIPTION
removed old references to lcplib
added reference to the branches instead of duplicating the instructions.